### PR TITLE
Resolve issue where Pandoc couldn't find PDF assets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,21 @@
+# Version History
+
+## 0.5.0 (March 2, 2021)
+
+  * First documented version
+
+### Minor Updates
+
+  * 0.5.1 (March 5, 2021):
+
+    In previous versions the target's command was run in the project's
+    top level directory.  However, all asset (image) paths were
+    relative to the output file meaning that some tools (i.e. pandoc)
+    would not correctly resolve those paths.  So, starting in 0.5.1:
+
+    - A target's command is run from the directory containing the file
+      being generated (the `%o` command variable).
+
+    - A new command variable (`%p`) was introduced so a target's
+      command can refer to the project's top level directory if
+      needed.

--- a/edify.cabal
+++ b/edify.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               edify
-version:            0.5
+version:            0.5.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Peter Jones <pjones@devalot.com>
@@ -18,6 +18,7 @@ description:
 
 ------------------------------------------------------------------------------
 extra-source-files:
+  CHANGES.md
   data/config/*.yml
   README.md
   test/data/**/*.golden

--- a/src/Edify/Compiler/Shake.hs
+++ b/src/Edify/Compiler/Shake.hs
@@ -42,6 +42,7 @@ import qualified Edify.Compiler.Stack as Stack
 import qualified Edify.Compiler.User as User
 import qualified Edify.Markdown.AST as AST
 import qualified Edify.Project as Project
+import qualified Edify.Project.Target as Target
 import qualified Edify.System.Exit as Exit
 import qualified Edify.System.FilePath as FilePath
 import qualified Edify.System.Input as Input
@@ -327,12 +328,19 @@ targetRule project target =
     action :: FilePath -> FilePath -> Shake.Action ()
     action input output = do
       let ops =
-            [ Shake.Cwd (project ^. #projectTopLevel . #projectDirectory),
+            [ Shake.Cwd (FilePath.takeDirectory output),
               Shake.Shell,
               Shake.EchoStdout False,
               Shake.EchoStderr False
             ]
-          cmd = Project.targetCommand target (input, output)
+          args =
+            Target.CommandArgs
+              { Target.commandInputDir =
+                  project ^. #projectTopLevel . #projectDirectory,
+                Target.commandInputFile = input,
+                Target.commandOutputFile = output
+              }
+          cmd = Project.targetCommand target args
       Shake.need [input]
       Shake.command_ ops (toString cmd) []
 


### PR DESCRIPTION
  * Target commands are run from the output directory so relative
    paths to assets can be resolved

  * A new variable (`%p`) was added to allow target commands to refer
    to the project's top level directory.