### PR TITLE
Depend on project input file, add manual target dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,31 @@
 
 ## 0.6.0 (Unreleased)
 
+### New Features
+
+  * Manual dependencies can now be added to targets.  This is useful
+    if your target command uses a script or other file that, when
+    changed, should trigger a rebuild.
+
+    Use the `dependencies` key in the target definition to add
+    dependencies:
+
+    ```yml
+    targets:
+        - name: web
+          format: html
+
+          dependencies:
+            - meta/style.html
+
+          command:
+            pandoc --from=markdown
+                   --to=html
+                   --include-in-header=%p/meta/style.html
+                   --output=%o
+                   %i
+    ```
+
 ### Library Changes
 
   * A new module (`Edify.Compiler.Build`) has been added that provides

--- a/src/Edify/Compiler/Shake.hs
+++ b/src/Edify/Compiler/Shake.hs
@@ -174,8 +174,7 @@ assetEval ::
   (FilePath, FilePath) ->
   -- | Instructions converted to a Shake action.
   Shake.Action ()
-assetEval project compiler (input, output) = do
-  Shake.need [input]
+assetEval project compiler (input, output) =
   Free.iterM go (compiler (input, output))
   where
     go = \case
@@ -237,6 +236,7 @@ fileExtensionRule project (inputExt, extOut) f =
         let indir = project ^. #projectTopLevel . #projectDirectory
             outdir = project ^. #projectConfig . #projectOutputDirectory
             input = FilePath.toInputPathViaInputExt indir outdir inputExt output
+        Shake.need [input]
         f input output
 
 -- | Generate Shake rules for each asset compiler listed in the 'Asset.AssetMap'.
@@ -337,7 +337,7 @@ targetRule project target =
                 Target.commandOutputFile = output
               }
           cmd = Project.targetCommand target args
-      Shake.need [input]
+      Shake.need (Project.targetDependencies target)
       Shake.command_ ops (toString cmd) []
 
 -- | All Shake rules for building an entire project.


### PR DESCRIPTION
Fixes a bug where the project input file wasn't a dependency of the
output markdown file.  Dependencies are now unified via the
`fileExtensionRule` function.